### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.log-name || 'logs' }}
+          name: logs
           path: geequel-shell/build/reports/tests/test/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.log-name || 'logs' }}
-          path: /home/runner/work/geequel-shell/geequel-shell/geequel-shell/build/reports/tests/test/
+          path: geequel-shell/build/reports/tests/test/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
           cache: gradle
       - name: Build with Makefile
         run: make build && make test && make untested-zip
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: geequel-shell
+          path: out/geequel-shell.zip
       - name: Upload logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,11 @@ jobs:
           distribution: 'corretto'
           cache: gradle
       - name: Build with Makefile
-        run: make build && make test && make untested-zip
+        run: |
+          make info
+          make build
+          make test
+          make untested-zip
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 .DEFAULT: help
 .PHONY: help build clean zip run untested-zip test integration-test tyrekicking-test mutation-test install info
 
-gitdescribe := $(shell git describe --tags --match [0-9]*)
-lasttag := $(shell git describe --tags --match [0-9]* --abbrev=0)
+gitdescribe := $(shell git describe --tags --match '[0-9]*' 2>/dev/null || echo 0.0.1-alpha)
+gitafter := $(shell git describe --tags --match '[0-9]*' --all 2>/dev/null | perl -pe 'exit unless /-\d+-/;s<^tags/><>;s<^(?:\d+\.)+\d+-><>;s<-.*><>; s/^/modified-/ if /./')
+lasttag := $(shell git describe --tags --match '[0-9]*' --abbrev=0 2>/dev/null || echo 0.0.1-alpha)
 
 version ?= $(lasttag)
-versionlabel = $(shell echo ${version} | awk '{ sub("^[0-9]+.[0-9]+.[0-9]+-?", "", $$1); print }')
+versionlabel = $(shell (echo ${version} | perl -pe 's/^\d+\.\d+\.\d+-?//'; echo ${gitafter}) | grep . | head -1)
 versionnumber = $(shell echo ${version} | awk '{ sub("-.*$$", "", $$1); print }')
 
 pkgversion ?= 1

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ ext {
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
     evaluatorVersion = '3.5.14'
-    neo4jJavaDriverVersion = '1.7.5'
+    neo4jJavaDriverVersion = '1.7.6'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'
     jlineVersion = '2.14.6'

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ subprojects {
 }
 
 ext {
-    // Only match tags starting with a number to avoid ongdb-xxx changelog tags
+    // Only match tags starting with a number to avoid ongdb-xxx / geequel-xxx changelog tags
     gitVersion = 'git describe --tags --match [0-9]*'.execute([], project.rootDir).text.trim()
 
     if (project.hasProperty('buildVersion')) {

--- a/geequel-shell/src/dist/geequel-shell.bat
+++ b/geequel-shell/src/dist/geequel-shell.bat
@@ -82,7 +82,7 @@ rem Get arguments from the 4NT Shell from JP Software
 set CMD_LINE_ARGS=%$
 
 :execute
-rem Setup the command line
+rem Set up the command line
 
 SETLOCAL EnableDelayedExpansion
 SET GEEQUEL_SHELL_JAR=

--- a/geequel-shell/src/main/java/org/neo4j/shell/ParameterMap.java
+++ b/geequel-shell/src/main/java/org/neo4j/shell/ParameterMap.java
@@ -26,7 +26,7 @@ import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
- * An object which keeps named parameters and allows them them to be set/unset.
+ * An object which keeps named parameters and allows them to be set/unset.
  */
 public interface ParameterMap {
     /**

--- a/geequel-shell/src/main/java/org/neo4j/shell/commands/Help.java
+++ b/geequel-shell/src/main/java/org/neo4j/shell/commands/Help.java
@@ -36,7 +36,7 @@ public class Help implements Command {
     public static final String COMMAND_NAME = ":help";
     private final Logger logger;
     private final CommandHelper commandHelper;
-    public static String CYPHER_REFCARD_LINK = "https://neo4j.com/docs/developer-manual/current/cypher/";
+    public static String CYPHER_REFCARD_LINK = "https://docs.graphfoundation.org/docs/category/query-language-docs";
 
     public Help(@Nonnull final Logger shell, @Nonnull final CommandHelper commandHelper) {
         this.logger = shell;

--- a/geequel-shell/src/test/java/org/neo4j/shell/MainTest.java
+++ b/geequel-shell/src/test/java/org/neo4j/shell/MainTest.java
@@ -399,7 +399,7 @@ public class MainTest {
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
 
         verify(printStream).println(argument.capture());
-        assertTrue(argument.getValue().matches("Geequel-Shell ( \\d+\\.\\d+\\.\\d+.*)?"));
+        assertTrue(argument.getValue().matches("Geequel-Shell (\\d+\\.\\d+\\.\\d+.*)?"));
     }
 
     @Test

--- a/geequel-shell/src/test/java/org/neo4j/shell/parser/ShellStatementParserTest.java
+++ b/geequel-shell/src/test/java/org/neo4j/shell/parser/ShellStatementParserTest.java
@@ -378,7 +378,7 @@ public class ShellStatementParserTest {
     }
 
     @Test
-    public void quoteInBlockomment() throws Exception {
+    public void quoteInBlockComment() throws Exception {
         // when
         parser.parseMoreText("/* `;\n;*/\n;");
 

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -61,7 +61,7 @@ if "x%~1" == "x" goto execute
 set CMD_LINE_ARGS=%*
 
 :execute
-@rem Setup the command line
+@rem Set up the command line
 
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 


### PR DESCRIPTION
* Update Java Driver Version to 1.7.6
* Link to graphfoundation query language docs
* ci: Upload geequel-shell artifact -- see https://github.com/jsoref/geequel-shell/actions/runs/15454211233
* ci: Fix versioning
   - For forks that have no tags, a version of `Geequel-Shell 0.0.1-alpha` will be picked, as in https://github.com/jsoref/geequel-shell/actions/runs/15454211233
   - For forks with tags where the tag is the current commit, the version is as expected `Geequel-Shell 1.0.5` https://github.com/check-spelling-sandbox/geequel-shell/actions/runs/15454103434
   - For versions where the tag is in the past, a version like `Geequel-Shell 1.0.4-11-g9145d91` https://github.com/check-spelling-sandbox/geequel-shell/actions/runs/15454040615 will be used

The goal is to be able to distinguish the various cases. Note that most forks these days won't have tags which means `0.0.1-alpha` will be the default -- we could use the `g...` notation for that too, but I don't really think the people running their own home builds care that much -- we just want to be able to run the thing at all and not see nothing / get test failures.