### PR TITLE
Follow symlinks to find self

### DIFF
--- a/geequel-shell/src/dist/geequel-shell
+++ b/geequel-shell/src/dist/geequel-shell
@@ -84,7 +84,7 @@ _show_java_help() {
 }
 
 build_classpath() {
-  APP_HOME="$(cd "$(dirname "$0")" && pwd)"
+  APP_HOME="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
   # First try in sub directory
   JARPATH="$(find "${APP_HOME}" -name "geequel-shell.jar" )"
 


### PR DESCRIPTION
We have a symlink to `geequel-shell` in a directory other than where `geequel-shell` lives, which means that the preexisting code would look for the directory of our symlink, and then look for `geequel-shell.jar` in that directory, and then fail because it can't.

The correct thing to do is to find the realpath of the running script which will eventually find where `geequel-shell` lives and then look for the dirname of that file which will then be able to find the jar.